### PR TITLE
Correct IdentityProvider service's class name

### DIFF
--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -19,7 +19,7 @@ services:
         factory_method:  getServiceProvider
 
     surfnet_saml.hosted.identity_provider:
-        class:           Surfnet\SamlBundle\Entity\IdenityProvider
+        class:           Surfnet\SamlBundle\Entity\IdentityProvider
         factory_service: surfnet_saml.configuration.hosted_entities
         factory_method:  getIdentityProvider
 


### PR DESCRIPTION
Does not necessarily pose a problem, but helps IDEs, and, well... it was just plain wrong.