### PR TITLE
Make authentication context an array, parity with getter

### DIFF
--- a/src/SAML2/AuthnRequest.php
+++ b/src/SAML2/AuthnRequest.php
@@ -110,11 +110,11 @@ class AuthnRequest
     }
 
     /**
-     * @param string $requestedAuthnClassRef
+     * @param array $requestedAuthnClassRef
      */
-    public function setAuthenticationContext($requestedAuthnClassRef)
+    public function setAuthenticationContext(array $requestedAuthnClassRef)
     {
-        $authnContext = ['AuthnContextClassRef' => [$requestedAuthnClassRef]];
+        $authnContext = ['AuthnContextClassRef' => $requestedAuthnClassRef];
         $this->request->setRequestedAuthnContext($authnContext);
     }
 


### PR DESCRIPTION
When setting the AuthnContextClassRef, accept an array. This creates parity with the getter, which also returns an array. This also fixes the RA, which set an authn context `array($requiredLoa)`. It is the only place where `setAuthenticationContext()` is used afaik.