### PR TITLE
Enable debug logging of signature verification

### DIFF
--- a/build-pre-commit.xml
+++ b/build-pre-commit.xml
@@ -63,7 +63,6 @@
                 <tokenfilter>
                     <containsregex pattern="src/(?!Tests).*$"/>
                 </tokenfilter>
-                <deletecharacters chars="\n"/>
                 <trim/>
                 <ignoreblank/>
                 <tokenfilter delimoutput=","/>

--- a/src/Http/RedirectBinding.php
+++ b/src/Http/RedirectBinding.php
@@ -120,7 +120,7 @@ class RedirectBinding
         }
 
         $serviceProvider = $this->entityRepository->getServiceProvider($authnRequest->getServiceProvider());
-        if (!$this->signatureVerifier->hasValidSignature($authnRequest, $serviceProvider)) {
+        if (!$this->signatureVerifier->hasValidSignature($authnRequest, $serviceProvider, $this->logger)) {
             throw new BadRequestHttpException(
                 'The SAMLRequest has been signed, but the signature could not be validated'
             );

--- a/src/Http/RedirectBinding.php
+++ b/src/Http/RedirectBinding.php
@@ -120,7 +120,7 @@ class RedirectBinding
         }
 
         $serviceProvider = $this->entityRepository->getServiceProvider($authnRequest->getServiceProvider());
-        if (!$this->signatureVerifier->hasValidSignature($authnRequest, $serviceProvider, $this->logger)) {
+        if (!$this->signatureVerifier->hasValidSignature($authnRequest, $serviceProvider)) {
             throw new BadRequestHttpException(
                 'The SAMLRequest has been signed, but the signature could not be validated'
             );

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -53,6 +53,7 @@ services:
         class: Surfnet\SamlBundle\Signing\SignatureVerifier
         arguments:
             - @surfnet_saml.saml2.keyloader
+            - @logger
 
     surfnet_saml.saml2.bridge_container:
         class: Surfnet\SamlBundle\SAML2\BridgeContainer

--- a/src/Signing/SignatureVerifier.php
+++ b/src/Signing/SignatureVerifier.php
@@ -34,11 +34,18 @@ class SignatureVerifier
     private $keyLoader;
 
     /**
-     * @param KeyLoader       $keyLoader
+     * @var LoggerInterface
      */
-    public function __construct(KeyLoader $keyLoader)
+    private $logger;
+
+    /**
+     * @param KeyLoader       $keyLoader
+     * @param LoggerInterface $logger
+     */
+    public function __construct(KeyLoader $keyLoader, LoggerInterface $logger)
     {
         $this->keyLoader = $keyLoader;
+        $this->logger = $logger;
     }
 
     /**
@@ -46,24 +53,24 @@ class SignatureVerifier
      * @param ServiceProvider $serviceProvider
      * @return bool
      */
-    public function hasValidSignature(AuthnRequest $request, ServiceProvider $serviceProvider, LoggerInterface $logger)
+    public function hasValidSignature(AuthnRequest $request, ServiceProvider $serviceProvider)
     {
-        $logger->debug(sprintf('Extracting public keys for ServiceProvider "%s"', $serviceProvider->getEntityId()));
+        $this->logger->debug(sprintf('Extracting public keys for ServiceProvider "%s"', $serviceProvider->getEntityId()));
 
         $keys = $this->keyLoader->extractPublicKeys($serviceProvider);
 
-        $logger->debug(sprintf('Found "%d" keys, filtering the keys to get X509 keys', $keys->count()));
+        $this->logger->debug(sprintf('Found "%d" keys, filtering the keys to get X509 keys', $keys->count()));
         $x509Keys = $keys->filter(function (SAML2_Certificate_Key $key) {
             return $key instanceof SAML2_Certificate_X509;
         });
 
-        $logger->debug(sprintf(
+        $this->logger->debug(sprintf(
             'Found "%d" X509 keys, attempting to use each for signature verification',
             $x509Keys->count()
         ));
 
         foreach ($x509Keys as $key) {
-            if ($this->isSignedWith($request, $key, $logger)) {
+            if ($this->isSignedWith($request, $key)) {
                 return true;
             }
         }
@@ -77,18 +84,18 @@ class SignatureVerifier
      * @return bool
      * @throws \Exception
      */
-    public function isSignedWith(AuthnRequest $request, SAML2_Certificate_X509 $publicKey, LoggerInterface $logger)
+    public function isSignedWith(AuthnRequest $request, SAML2_Certificate_X509 $publicKey)
     {
-        $logger->debug(sprintf('Attempting to verify signature with certificate "%s"', $publicKey->getCertificate()));
+        $this->logger->debug(sprintf('Attempting to verify signature with certificate "%s"', $publicKey->getCertificate()));
         $key = new XMLSecurityKey(XMLSecurityKey::RSA_SHA256, array('type' => 'public'));
         $key->loadKey($publicKey->getCertificate());
 
         if ($key->verifySignature($request->getSignedRequestQuery(), $request->getSignature())) {
-            $logger->debug('Signature VERIFIED');
+            $this->logger->debug('Signature VERIFIED');
             return true;
         }
 
-        $logger->debug('Signature NOT VERIFIED');
+        $this->logger->debug('Signature NOT VERIFIED');
 
         return false;
     }

--- a/src/Signing/SignatureVerifier.php
+++ b/src/Signing/SignatureVerifier.php
@@ -75,6 +75,8 @@ class SignatureVerifier
             }
         }
 
+        $this->logger->debug('Signature could not be verified with any of the found X509 keys.');
+
         return false;
     }
 

--- a/src/Signing/SignatureVerifier.php
+++ b/src/Signing/SignatureVerifier.php
@@ -79,7 +79,7 @@ class SignatureVerifier
      */
     public function isSignedWith(AuthnRequest $request, SAML2_Certificate_X509 $publicKey, LoggerInterface $logger)
     {
-        $logger->debug('Attempting to verify signature with certificate "%s"', $publicKey->getCertificate());
+        $logger->debug(sprintf('Attempting to verify signature with certificate "%s"', $publicKey->getCertificate()));
         $key = new XMLSecurityKey(XMLSecurityKey::RSA_SHA256, array('type' => 'public'));
         $key->loadKey($publicKey->getCertificate());
 


### PR DESCRIPTION
This is a request from @pmeulen so that debugging is easier when Response signature verfication fails.

- [ ] Inject the logger rather than pass in method call.