### PR TITLE
Add NameID support to AuthnRequest (Subject)

### DIFF
--- a/src/SAML2/AuthnRequest.php
+++ b/src/SAML2/AuthnRequest.php
@@ -19,6 +19,7 @@
 namespace Surfnet\SamlBundle\SAML2;
 
 use SAML2_AuthnRequest;
+use SAML2_Const;
 use Surfnet\SamlBundle\Exception\InvalidArgumentException;
 
 class AuthnRequest
@@ -137,8 +138,8 @@ class AuthnRequest
     }
 
     /**
-     * @param      $nameId
-     * @param null $format
+     * @param string      $nameId
+     * @param string|null $format
      */
     public function setSubject($nameId, $format = null)
     {
@@ -152,7 +153,7 @@ class AuthnRequest
 
         $nameId = [
             'Value' => $nameId,
-            'Format' => ($format ?: \SAML2_Const::NAMEID_UNSPECIFIED)
+            'Format' => ($format ?: SAML2_Const::NAMEID_UNSPECIFIED)
         ];
 
         $this->request->setNameId($nameId);

--- a/src/SAML2/AuthnRequest.php
+++ b/src/SAML2/AuthnRequest.php
@@ -19,6 +19,7 @@
 namespace Surfnet\SamlBundle\SAML2;
 
 use SAML2_AuthnRequest;
+use Surfnet\SamlBundle\Exception\InvalidArgumentException;
 
 class AuthnRequest
 {
@@ -107,6 +108,54 @@ class AuthnRequest
     {
         $authnContext = ['AuthnContextClassRef' => [$authnClassRef]];
         $this->request->setRequestedAuthnContext($authnContext);
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getNameId()
+    {
+        $nameId = $this->request->getNameId();
+        if (!is_array($nameId) || !array_key_exists('Value', $nameId)) {
+            return null;
+        }
+
+        return $nameId['Value'];
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getNameIdFormat()
+    {
+        $nameId = $this->request->getNameId();
+        if (!is_array($nameId) || !array_key_exists('Format', $nameId)) {
+            return null;
+        }
+
+        return $nameId['Format'];
+    }
+
+    /**
+     * @param      $nameId
+     * @param null $format
+     */
+    public function setSubject($nameId, $format = null)
+    {
+        if (!is_string($nameId)) {
+            throw InvalidArgumentException::invalidType('string', 'nameId', $nameId);
+        }
+
+        if (!is_null($format) && !is_string($format)) {
+            throw InvalidArgumentException::invalidType('string', 'format', $format);
+        }
+
+        $nameId = [
+            'Value' => $nameId,
+            'Format' => ($format ?: \SAML2_Const::NAMEID_UNSPECIFIED)
+        ];
+
+        $this->request->setNameId($nameId);
     }
 
     /**

--- a/src/Tests/SAML2/AuthnRequestTest.php
+++ b/src/Tests/SAML2/AuthnRequestTest.php
@@ -1,0 +1,116 @@
+<?php
+
+/**
+ * Copyright 2014 SURFnet bv
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\SamlBundle\Tests\SAML2;
+
+use DOMDocument;
+use PHPUnit_Framework_TestCase as UnitTest;
+use SAML2_AuthnRequest;
+use Surfnet\SamlBundle\SAML2\AuthnRequest;
+
+class AuthnRequestTest extends UnitTest
+{
+    /**
+     * @var string
+     */
+    private $authRequestWithSubject = <<<AUTHNREQUEST_WITH_SUBJECT
+<samlp:AuthnRequest
+    xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"
+    xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"
+    AssertionConsumerServiceIndex="1"
+    Destination="https://tiqr.stepup.org/idp/profile/saml2/Redirect/SSO"
+    ID="_2b0226190ca1c22de6f66e85f5c95158"
+    IssueInstant="2014-09-22T13:42:00Z"
+    Version="2.0">
+  <saml:Issuer>https://gateway.stepup.org/saml20/sp/metadata</saml:Issuer>
+  <saml:Subject>
+        <saml:NameID Format="urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified">user@example.org</saml:NameID>
+  </saml:Subject>
+</samlp:AuthnRequest>
+AUTHNREQUEST_WITH_SUBJECT;
+
+    /**
+     * @var string
+     */
+    private $authRequestNoSubject = <<<AUTHNREQUEST_NO_SUBJECT
+<samlp:AuthnRequest
+    xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"
+    xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"
+    AssertionConsumerServiceIndex="1"
+    Destination="https://tiqr.stepup.org/idp/profile/saml2/Redirect/SSO"
+    ID="_2b0226190ca1c22de6f66e85f5c95158"
+    IssueInstant="2014-09-22T13:42:00Z"
+    Version="2.0">
+  <saml:Issuer>https://gateway.stepup.org/saml20/sp/metadata</saml:Issuer>
+</samlp:AuthnRequest>
+AUTHNREQUEST_NO_SUBJECT;
+
+    /**
+     * @var string
+     */
+    private $nameId = 'user@example.org';
+
+    /**
+     * @var string
+     */
+    private $format = 'urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified';
+
+    /**
+     * @test
+     * @group saml2
+     * @dataProvider provideNameIDAndFormatCombinations
+     *
+     * @param $nameId
+     * @param $format
+     */
+    public function setting_the_subject_generates_valid_xml($nameId, $format)
+    {
+        $domDocument = new DOMDocument();
+        $domDocument->loadXML($this->authRequestNoSubject);
+        $request = new SAML2_AuthnRequest($domDocument->documentElement);
+
+        $authnRequest = AuthnRequest::createNew($request);
+        $authnRequest->setSubject($nameId, $format);
+
+        $this->assertXmlStringEqualsXmlString($this->authRequestWithSubject, $authnRequest->getUnsignedXML());
+    }
+
+    /**
+     * @test
+     * @group saml2
+     */
+    public function the_nameid_and_format_can_be_retrieved_from_the_authnrequest()
+    {
+        $domDocument = new DOMDocument();
+        $domDocument->loadXML($this->authRequestWithSubject);
+        $request = new SAML2_AuthnRequest($domDocument->documentElement);
+
+        $authnRequest = AuthnRequest::createNew($request);
+
+        $this->assertEquals($this->nameId, $authnRequest->getNameId());
+        $this->assertEquals($this->format, $authnRequest->getNameIdFormat());
+    }
+
+    public function provideNameIDAndFormatCombinations()
+    {
+        return [
+            'NameID without Format' => [$this->nameId, null],
+            'NameID with Format'    => [$this->nameId, $this->format]
+        ];
+    }
+}

--- a/src/Tests/SAML2/Response/Assertion/InResponseToTest.php
+++ b/src/Tests/SAML2/Response/Assertion/InResponseToTest.php
@@ -31,6 +31,7 @@ class InResponseToTest extends UnitTest
      *
      * @test
      * @group saml2-response
+     * @group saml2
      * @dataProvider provideAssertionsWithoutInResponseTo
      */
     public function assertions_without_in_response_to_are_tested_as_if_in_response_to_is_null(SAML2_Assertion $assertion)
@@ -42,6 +43,7 @@ class InResponseToTest extends UnitTest
     /**
      * @test
      * @group saml2-response
+     * @group saml2
      */
     public function in_reponse_to_equality_is_strictly_checked()
     {


### PR DESCRIPTION
This is required for the Gateway to be able to read and write the subject from/to AuthnRequests.