### PR TITLE
Limit scope of disabled external entity loading to prevent conflicts

### DIFF
--- a/src/Http/PostBinding.php
+++ b/src/Http/PostBinding.php
@@ -67,7 +67,10 @@ class PostBinding
         }
 
         $response = base64_decode($response);
+
+        $previous = libxml_disable_entity_loader(true);
         $asXml    = SAML2_DOMDocumentFactory::fromString($response);
+        libxml_disable_entity_loader($previous);
 
         try {
             $assertions = $this->responseProcessor->process(

--- a/src/SAML2/AuthnRequestFactory.php
+++ b/src/SAML2/AuthnRequestFactory.php
@@ -41,7 +41,10 @@ class AuthnRequestFactory
         // the GET parameter is already urldecoded by Symfony, so we should not do it again.
         $samlRequest = gzinflate(base64_decode($httpRequest->get(AuthnRequest::PARAMETER_REQUEST)));
 
+        // additional security against XXE Processing vulnerability
+        $previous = libxml_disable_entity_loader(true);
         $document = SAML2_DOMDocumentFactory::fromString($samlRequest);
+        libxml_disable_entity_loader($previous);
 
         $request = SAML2_Message::fromXML($document->firstChild);
 

--- a/src/SurfnetSamlBundle.php
+++ b/src/SurfnetSamlBundle.php
@@ -36,9 +36,6 @@ class SurfnetSamlBundle extends Bundle
 
     public function boot()
     {
-        // additional security against XXE Processing vulnerability
-        libxml_disable_entity_loader(true);
-
         $bridgeContainer = $this->container->get('surfnet_saml.saml2.bridge_container');
         SAML2_Compat_ContainerSingleton::setContainer($bridgeContainer);
     }


### PR DESCRIPTION
Using it in the `boot` function of the bundle essentially globally disables this for the application that uses this bundle. Which is a good thing, except for the fact that SF translations require this, so templates and console won't work etc. 

This change limits the XXE defense to where it is actually needed, no longer contaminating the runtime.