### PR TITLE
Improve request decoding, handle base64 and gzinflate errors

### DIFF
--- a/src/Http/Exception/InvalidRequestException.php
+++ b/src/Http/Exception/InvalidRequestException.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * Copyright 2015 SURFnet bv
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\SamlBundle\Http\Exception;
+
+use Surfnet\SamlBundle\Exception\RuntimeException;
+
+class InvalidRequestException extends RuntimeException
+{
+}

--- a/src/SAML2/AuthnRequestFactory.php
+++ b/src/SAML2/AuthnRequestFactory.php
@@ -45,7 +45,7 @@ class AuthnRequestFactory
             throw new InvalidRequestException('Failed decoding the request, did not receive a valid base64 string');
         }
 
-        // gzinflate throws an error
+        // Catch any errors gzinflate triggers
         $errorNo = $errorMessage = null;
         set_error_handler(function ($number, $message) use (&$errorNo, &$errorMessage) {
             $errorNo      = $number;

--- a/src/Tests/SAML2/AuthnRequestFactoryTest.php
+++ b/src/Tests/SAML2/AuthnRequestFactoryTest.php
@@ -26,14 +26,13 @@ class AuthnRequestFactoryTest extends UnitTest
 
     /**
      * @test
-     * @group                    saml2
+     * @group saml2
      *
      * @expectedException \Surfnet\SamlBundle\Http\Exception\InvalidRequestException
      * @expectedExceptionMessage Failed inflating the request;
      */
     public function an_exception_is_thrown_when_a_request_cannot_be_inflated()
     {
-        // the $ is invalid since it is outside the base64 alphabet and we deserialize in strict mode.
         $request = new Request([AuthnRequest::PARAMETER_REQUEST => base64_encode('nope, not deflated')]);
 
         AuthnRequestFactory::createFromHttpRequest($request);

--- a/src/Tests/SAML2/AuthnRequestFactoryTest.php
+++ b/src/Tests/SAML2/AuthnRequestFactoryTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Surfnet\SamlBundle\Tests\SAML2;
+
+use PHPUnit_Framework_TestCase as UnitTest;
+use Surfnet\SamlBundle\SAML2\AuthnRequest;
+use Surfnet\SamlBundle\SAML2\AuthnRequestFactory;
+use Symfony\Component\HttpFoundation\Request;
+
+class AuthnRequestFactoryTest extends UnitTest
+{
+    /**
+     * @test
+     * @group saml2
+     *
+     * @expectedException \Surfnet\SamlBundle\Http\Exception\InvalidRequestException
+     * @expectedExceptionMessage Failed decoding the request, did not receive a valid base64 string
+     */
+    public function an_exception_is_thrown_when_a_request_is_not_properly_base64_encoded()
+    {
+        // the $ is invalid since it is outside the base64 alphabet and we deserialize in strict mode.
+        $request = new Request([AuthnRequest::PARAMETER_REQUEST => '$']);
+
+        AuthnRequestFactory::createFromHttpRequest($request);
+    }
+
+    /**
+     * @test
+     * @group                    saml2
+     *
+     * @expectedException \Surfnet\SamlBundle\Http\Exception\InvalidRequestException
+     * @expectedExceptionMessage Failed inflating the request;
+     */
+    public function an_exception_is_thrown_when_a_request_cannot_be_inflated()
+    {
+        // the $ is invalid since it is outside the base64 alphabet and we deserialize in strict mode.
+        $request = new Request([AuthnRequest::PARAMETER_REQUEST => base64_encode('nope, not deflated')]);
+
+        AuthnRequestFactory::createFromHttpRequest($request);
+    }
+}


### PR DESCRIPTION
As per https://github.com/simplesamlphp/saml2/pull/55, seeing this bundle provides its own bindings we should do the same.