### PR TITLE
Remove Multiplicity from AttributeDefinition

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,0 +1,12 @@
+# UPGRADE FROM 1.X to 2.X
+
+## Multiplicity
+
+The multiplicity functionality has been removed from `Surfnet\SamlBundle\SAML2\Attribute\AttributeDefinition`.
+ This means that the method `AttributeDefinition::getMultiplicity()` no longer exists. Furthermore, the related
+ constants `AttributeDefinition::MULTIPLICITY_SINGLE` and `AttributeDefinition::MULTIPLICITY_MULTIPLE` have been
+ removed. 
+ 
+**WARNING** The value of an attribute is now always an array of strings, it can no longer be `null` or `string`.
+ This means code relying on the values of attributes should be modified to always accept `string[]` as return value
+ and handle accordingly.

--- a/src/SAML2/Attribute/Attribute.php
+++ b/src/SAML2/Attribute/Attribute.php
@@ -18,8 +18,6 @@
 
 namespace Surfnet\SamlBundle\SAML2\Attribute;
 
-use UnexpectedValueException;
-
 class Attribute
 {
     /**
@@ -38,18 +36,8 @@ class Attribute
      */
     public function __construct(AttributeDefinition $attributeDefinition, array $value)
     {
-        if ($attributeDefinition->getMultiplicity() === AttributeDefinition::MULTIPLICITY_SINGLE
-            && count($value) > 1
-        ) {
-            throw new UnexpectedValueException(sprintf(
-                'AttributeDefinition "%s" has a single-value multiplicity, got "%d" values',
-                $attributeDefinition->getName(),
-                count($value)
-            ));
-        }
-
         $this->attributeDefinition = $attributeDefinition;
-        $this->value = $value;
+        $this->value               = $value;
     }
 
     /**
@@ -61,18 +49,10 @@ class Attribute
     }
 
     /**
-     * @return null|string[]|string
+     * @return string[]
      */
     public function getValue()
     {
-        if ($this->attributeDefinition->getMultiplicity() === AttributeDefinition::MULTIPLICITY_SINGLE) {
-            if (empty($this->value)) {
-                return null;
-            }
-
-            return reset($this->value);
-        }
-
         return $this->value;
     }
 

--- a/src/SAML2/Attribute/AttributeDefinition.php
+++ b/src/SAML2/Attribute/AttributeDefinition.php
@@ -23,18 +23,10 @@ use Surfnet\SamlBundle\Exception\LogicException;
 
 class AttributeDefinition
 {
-    const MULTIPLICITY_SINGLE   = 1;
-    const MULTIPLICITY_MULTIPLE = 2;
-
     /**
      * @var string the name of the saml attribute
      */
     private $name;
-
-    /**
-     * @var int the multiplicity of this attribute
-     */
-    private $multiplicity;
 
     /**
      * @var string the urn:mace identifier of this attribute
@@ -50,9 +42,8 @@ class AttributeDefinition
      * @param string $name
      * @param string $urnMace
      * @param string $urnOid
-     * @param int    $multiplicity
      */
-    public function __construct($name, $urnMace = null, $urnOid = null, $multiplicity = self::MULTIPLICITY_SINGLE)
+    public function __construct($name, $urnMace = null, $urnOid = null)
     {
         if (!is_string($name)) {
             throw InvalidArgumentException::invalidType('string', 'name', $name);
@@ -70,16 +61,7 @@ class AttributeDefinition
             throw new LogicException('An AttributeDefinition should have at least either a mace or an oid urn');
         }
 
-        if (!in_array($multiplicity, [self::MULTIPLICITY_SINGLE, self::MULTIPLICITY_MULTIPLE])) {
-            throw new InvalidArgumentException(sprintf(
-                'Multiplicity should be once of "%s", "%s" given',
-                implode('", "', [self::MULTIPLICITY_SINGLE, self::MULTIPLICITY_MULTIPLE]),
-                $multiplicity
-            ));
-        }
-
         $this->name         = $name;
-        $this->multiplicity = $multiplicity;
         $this->urnMace      = $urnMace;
         $this->urnOid       = $urnOid;
     }
@@ -125,14 +107,6 @@ class AttributeDefinition
     }
 
     /**
-     * @return int
-     */
-    public function getMultiplicity()
-    {
-        return $this->multiplicity;
-    }
-
-    /**
      * @param AttributeDefinition $other
      * @return bool
      */
@@ -140,7 +114,6 @@ class AttributeDefinition
     {
         return $this->name === $other->name
             && $this->urnOid === $other->urnOid
-            && $this->urnMace === $other->urnMace
-            && $this->multiplicity === $other->multiplicity;
+            && $this->urnMace === $other->urnMace;
     }
 }


### PR DESCRIPTION
The SAML2 specification does not make any mention
of multiplicity. Furthermore the functionality
was used sparsely if at all and should not have
been relied on as it was configuration based,
which could have changed causing a BC break in
and of itself as an Attribute could suddenly
cause exceptions to be thrown when configuration
changed or was overridden.