### PR TITLE
Fix deprecated use of @ in YML

### DIFF
--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -9,55 +9,55 @@ services:
         public: false
         class: Surfnet\SamlBundle\Entity\HostedEntities
         arguments:
-            - @router
-            - @request_stack
+            - '@router'
+            - '@request_stack'
             - null # Replaced in the Surfnet\SamlBundle\DependencyInjection\SurfnetSamlExtension based on configuration
             - null # Replaced in the Surfnet\SamlBundle\DependencyInjection\SurfnetSamlExtension based on configuration
 
     surfnet_saml.hosted.service_provider:
         class:   Surfnet\SamlBundle\Entity\ServiceProvider
-        factory: [@surfnet_saml.configuration.hosted_entities, getServiceProvider]
+        factory: ['@surfnet_saml.configuration.hosted_entities', getServiceProvider]
 
     surfnet_saml.hosted.identity_provider:
         class:   Surfnet\SamlBundle\Entity\IdentityProvider
-        factory: [@surfnet_saml.configuration.hosted_entities, getIdentityProvider]
+        factory: ['@surfnet_saml.configuration.hosted_entities', getIdentityProvider]
 
     surfnet_saml.http.redirect_binding:
         class: Surfnet\SamlBundle\Http\RedirectBinding
         arguments:
-            - @logger
-            - @surfnet_saml.signing.signature_verifier
-            - @?surfnet_saml.entity.entity_repository
+            - '@logger'
+            - '@surfnet_saml.signing.signature_verifier'
+            - '@?surfnet_saml.entity.entity_repository'
 
     surfnet_saml.http.post_binding:
         class: Surfnet\SamlBundle\Http\PostBinding
         arguments:
-            - @surfnet_saml.saml2.response_processor
+            - '@surfnet_saml.saml2.response_processor'
 
     surfnet_saml.metadata_factory:
         class: Surfnet\SamlBundle\Metadata\MetadataFactory
         arguments:
-            - @templating
-            - @router
-            - @surfnet_saml.signing_service
-            - @surfnet_saml.configuration.metadata
+            - '@templating'
+            - '@router'
+            - '@surfnet_saml.signing_service'
+            - '@surfnet_saml.configuration.metadata'
 
     surfnet_saml.signing_service:
         class: Surfnet\SamlBundle\Service\SigningService
         arguments:
-            - @surfnet_saml.saml2.keyloader
-            - @surfnet_saml.saml2.privatekeyloader
+            - '@surfnet_saml.saml2.keyloader'
+            - '@surfnet_saml.saml2.privatekeyloader'
 
     surfnet_saml.signing.signature_verifier:
         class: Surfnet\SamlBundle\Signing\SignatureVerifier
         arguments:
-            - @surfnet_saml.saml2.keyloader
-            - @logger
+            - '@surfnet_saml.saml2.keyloader'
+            - '@logger'
 
     surfnet_saml.saml2.bridge_container:
         class: Surfnet\SamlBundle\SAML2\BridgeContainer
         arguments:
-            - @logger
+            - '@logger'
 
     surfnet_saml.saml2.keyloader:
         public: false
@@ -71,9 +71,9 @@ services:
         public: false
         class: SAML2_Response_Processor
         arguments:
-            - @logger
+            - '@logger'
 
     surfnet_saml.logger:
         class: Surfnet\SamlBundle\Monolog\SamlAuthenticationLogger
         arguments:
-            - @logger
+            - '@logger'


### PR DESCRIPTION
Not quoting a scalar starting with '@' is deprecated since Symfony 2.8.