### PR TITLE
Fix AuthnRequest->isSigned()

### DIFF
--- a/src/SAML2/AuthnRequest.php
+++ b/src/SAML2/AuthnRequest.php
@@ -172,7 +172,7 @@ class AuthnRequest
      */
     public function isSigned()
     {
-        return isset($this->signature);
+        return !empty($this->signature);
     }
 
     /**


### PR DESCRIPTION
When `$signature` in `AuthnRequest::create` is `""` or `null`, `base64_decode` will return an empty string. In addition, whenever the decoding fails, `base64_decode` will return `false`. After applying this patch, these cases are handled properly.