### PR TITLE
Require AuthnRequests to be signed again

### DIFF
--- a/src/Http/RedirectBinding.php
+++ b/src/Http/RedirectBinding.php
@@ -37,11 +37,6 @@ use XMLSecurityKey;
 class RedirectBinding
 {
     /**
-     * @var \Surfnet\SamlBundle\Entity\ServiceProviderRepository
-     */
-    private $entityRepository;
-
-    /**
      * @var \Psr\Log\LoggerInterface
      */
     private $logger;
@@ -51,14 +46,19 @@ class RedirectBinding
      */
     private $signatureVerifier;
 
+    /**
+     * @var \Surfnet\SamlBundle\Entity\ServiceProviderRepository
+     */
+    private $entityRepository;
+
     public function __construct(
         LoggerInterface $logger,
         SignatureVerifier $signatureVerifier,
         ServiceProviderRepository $repository = null
     ) {
-        $this->entityRepository = $repository;
         $this->logger = $logger;
         $this->signatureVerifier = $signatureVerifier;
+        $this->entityRepository = $repository;
     }
 
     /**

--- a/src/SAML2/AuthnRequest.php
+++ b/src/SAML2/AuthnRequest.php
@@ -77,7 +77,7 @@ class AuthnRequest
         if ($relayState) {
             $authnRequest->request->setRelayState($relayState);
         }
-        $authnRequest->signature          = base64_decode($signature);
+        $authnRequest->signature          = base64_decode($signature, true);
         $authnRequest->signatureAlgorithm = $signatureAlgorithm;
 
         return $authnRequest;

--- a/src/SAML2/AuthnRequest.php
+++ b/src/SAML2/AuthnRequest.php
@@ -59,18 +59,37 @@ class AuthnRequest
 
     /**
      * @param SAML2_AuthnRequest $request
-     * @param string             $rawRequest
-     * @param string             $relayState
-     * @param string             $signature
-     * @param string             $signatureAlgorithm
+     * @param string $rawRequest
+     * @param string $relayState
      * @return AuthnRequest
      */
-    public static function create(
-        SAML2_AuthnRequest $request,
-        $rawRequest,
-        $relayState,
-        $signature,
-        $signatureAlgorithm
+    public static function createUnsigned(
+      SAML2_AuthnRequest $request,
+      $rawRequest,
+      $relayState
+    ) {
+        $authnRequest = new self($request);
+        $authnRequest->rawRequest = $rawRequest;
+        if ($relayState) {
+            $authnRequest->request->setRelayState($relayState);
+        }
+        return $authnRequest;
+    }
+
+    /**
+     * @param SAML2_AuthnRequest $request
+     * @param string $rawRequest
+     * @param string $relayState
+     * @param string $signature
+     * @param string $signatureAlgorithm
+     * @return AuthnRequest
+     */
+    public static function createSigned(
+      SAML2_AuthnRequest $request,
+      $rawRequest,
+      $relayState,
+      $signature,
+      $signatureAlgorithm
     ) {
         $authnRequest = new self($request);
         $authnRequest->rawRequest = $rawRequest;
@@ -81,6 +100,31 @@ class AuthnRequest
         $authnRequest->signatureAlgorithm = $signatureAlgorithm;
 
         return $authnRequest;
+    }
+
+    /**
+     * @deprecated use ::createSigned (default) or ::createUnsigned
+     * @param SAML2_AuthnRequest $request
+     * @param string $rawRequest
+     * @param string $relayState
+     * @param string $signature
+     * @param string $signatureAlgorithm
+     * @return AuthnRequest
+     */
+    public static function create(
+      SAML2_AuthnRequest $request,
+      $rawRequest,
+      $relayState,
+      $signature,
+      $signatureAlgorithm
+    ) {
+        return static::createSigned(
+          $request,
+          $rawRequest,
+          $relayState,
+          $signature,
+          $signatureAlgorithm
+        );
     }
 
     public static function createNew(SAML2_AuthnRequest $req)

--- a/src/SAML2/AuthnRequest.php
+++ b/src/SAML2/AuthnRequest.php
@@ -64,15 +64,16 @@ class AuthnRequest
      * @return AuthnRequest
      */
     public static function createUnsigned(
-      SAML2_AuthnRequest $request,
-      $rawRequest,
-      $relayState
+        SAML2_AuthnRequest $request,
+        $rawRequest,
+        $relayState
     ) {
         $authnRequest = new self($request);
         $authnRequest->rawRequest = $rawRequest;
         if ($relayState) {
             $authnRequest->request->setRelayState($relayState);
         }
+
         return $authnRequest;
     }
 
@@ -85,18 +86,18 @@ class AuthnRequest
      * @return AuthnRequest
      */
     public static function createSigned(
-      SAML2_AuthnRequest $request,
-      $rawRequest,
-      $relayState,
-      $signature,
-      $signatureAlgorithm
+        SAML2_AuthnRequest $request,
+        $rawRequest,
+        $relayState,
+        $signature,
+        $signatureAlgorithm
     ) {
         $authnRequest = new self($request);
         $authnRequest->rawRequest = $rawRequest;
         if ($relayState) {
             $authnRequest->request->setRelayState($relayState);
         }
-        $authnRequest->signature          = base64_decode($signature, true);
+        $authnRequest->signature = base64_decode($signature, true);
         $authnRequest->signatureAlgorithm = $signatureAlgorithm;
 
         return $authnRequest;
@@ -112,18 +113,18 @@ class AuthnRequest
      * @return AuthnRequest
      */
     public static function create(
-      SAML2_AuthnRequest $request,
-      $rawRequest,
-      $relayState,
-      $signature,
-      $signatureAlgorithm
+        SAML2_AuthnRequest $request,
+        $rawRequest,
+        $relayState,
+        $signature,
+        $signatureAlgorithm
     ) {
         return static::createSigned(
-          $request,
-          $rawRequest,
-          $relayState,
-          $signature,
-          $signatureAlgorithm
+            $request,
+            $rawRequest,
+            $relayState,
+            $signature,
+            $signatureAlgorithm
         );
     }
 

--- a/src/SAML2/AuthnRequestFactory.php
+++ b/src/SAML2/AuthnRequestFactory.php
@@ -40,8 +40,48 @@ class AuthnRequestFactory
      * @param Request $httpRequest
      * @return AuthnRequest
      */
+    public static function createUnsignedFromHttpRequest(Request $httpRequest)
+    {
+        return AuthnRequest::createUnsigned(
+          self::createAuthnRequestFromHttpRequest($httpRequest),
+          $httpRequest->get(AuthnRequest::PARAMETER_REQUEST),
+          $httpRequest->get(AuthnRequest::PARAMETER_RELAY_STATE)
+        );
+    }
+
+    /**
+     * @param Request $httpRequest
+     * @return AuthnRequest
+     */
+    public static function createSignedFromHttpRequest(Request $httpRequest)
+    {
+        return AuthnRequest::createSigned(
+            self::createAuthnRequestFromHttpRequest($httpRequest),
+            $httpRequest->get(AuthnRequest::PARAMETER_REQUEST),
+            $httpRequest->get(AuthnRequest::PARAMETER_RELAY_STATE),
+            $httpRequest->get(AuthnRequest::PARAMETER_SIGNATURE),
+            $httpRequest->get(AuthnRequest::PARAMETER_SIGNATURE_ALGORITHM)
+        );
+    }
+
+    /**
+     * @deprecated use createSignedFromHttpRequest or createUnsignedFromHttpRequest
+     * @param Request $httpRequest
+     * @return AuthnRequest
+     */
     public static function createFromHttpRequest(Request $httpRequest)
     {
+        return static::createSignedFromHttpRequest($httpRequest);
+    }
+
+    /**
+     * @param Request $httpRequest
+     * @return SAML2_AuthnRequest
+     * @throws \Exception
+     */
+    private static function createAuthnRequestFromHttpRequest(
+      Request $httpRequest
+    ) {
         // the GET parameter is already urldecoded by Symfony, so we should not do it again.
         $samlRequest = base64_decode($httpRequest->get(AuthnRequest::PARAMETER_REQUEST), true);
         if ($samlRequest === false) {
@@ -79,13 +119,7 @@ class AuthnRequestFactory
             ));
         }
 
-        return AuthnRequest::create(
-            $request,
-            $httpRequest->get(AuthnRequest::PARAMETER_REQUEST),
-            $httpRequest->get(AuthnRequest::PARAMETER_RELAY_STATE),
-            $httpRequest->get(AuthnRequest::PARAMETER_SIGNATURE),
-            $httpRequest->get(AuthnRequest::PARAMETER_SIGNATURE_ALGORITHM)
-        );
+        return $request;
     }
 
     /**

--- a/src/SAML2/AuthnRequestFactory.php
+++ b/src/SAML2/AuthnRequestFactory.php
@@ -43,9 +43,9 @@ class AuthnRequestFactory
     public static function createUnsignedFromHttpRequest(Request $httpRequest)
     {
         return AuthnRequest::createUnsigned(
-          self::createAuthnRequestFromHttpRequest($httpRequest),
-          $httpRequest->get(AuthnRequest::PARAMETER_REQUEST),
-          $httpRequest->get(AuthnRequest::PARAMETER_RELAY_STATE)
+            self::createAuthnRequestFromHttpRequest($httpRequest),
+            $httpRequest->get(AuthnRequest::PARAMETER_REQUEST),
+            $httpRequest->get(AuthnRequest::PARAMETER_RELAY_STATE)
         );
     }
 
@@ -80,7 +80,7 @@ class AuthnRequestFactory
      * @throws \Exception
      */
     private static function createAuthnRequestFromHttpRequest(
-      Request $httpRequest
+        Request $httpRequest
     ) {
         // the GET parameter is already urldecoded by Symfony, so we should not do it again.
         $samlRequest = base64_decode($httpRequest->get(AuthnRequest::PARAMETER_REQUEST), true);


### PR DESCRIPTION
This behaviour was in 2.0, 2.1 and 2.2 but was broken in 2.3. This patch again requires signatures to be present and valid on the AuthnRequest but also allows projects to weaken this condition and forgo signature verification altogether.

Also switch to using strict base64 decoding for the signature.

This PR fixes https://github.com/SURFnet/Stepup-saml-bundle/pull/43.