### PR TITLE
Add `certificate_file` configuration option as an alternative to `certificate`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,9 +51,12 @@ surfnet_saml:
             sso_url: %surfnet_saml_remote_idp_sso_url%
             certificate: %surfnet_saml_remote_idp_certificate%
 ```
+
 The hosted configuration lists the configuration for the services (SP, IdP or both) that your application offers. SP and IdP
  functionality can be turned off and on individually through the repective `enabled` flags.
 The remote configuration lists, if enabled, the configuration for a remote IdP to connect to.
+The inlined certificate in the last line can be replaced with `certificate_file` containing a filesystem path to
+a file which contains said certificate.
 It is recommended to use parameters as listed above. The various `publickey` and `privatekey` variables are the
  contents of the key in a single line, without the certificate etc. delimiters. The use of parameters as listed above
  is highly recommended so that the actual key contents can be kept out of the configuration files (using for instance

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -144,10 +144,13 @@ class Configuration implements ConfigurationInterface
                         ->info('The name of the route to generate the SSO URL')
                     ->end()
                     ->scalarNode('certificate')
-                        ->isRequired()
                         ->info(
-                            'The contents of the certificate used to sign the AuthnResponse with, if different from'
-                            . ' the public key configured below'
+                            'The contents of the certificate used to sign the AuthnResponse with'
+                        )
+                    ->end()
+                    ->scalarNode('certificate_file')
+                        ->info(
+                            'A file containing the certificate used to sign the AuthnResponse with'
                         )
                     ->end()
                 ->end()

--- a/src/DependencyInjection/SurfnetSamlExtension.php
+++ b/src/DependencyInjection/SurfnetSamlExtension.php
@@ -158,8 +158,17 @@ class SurfnetSamlExtension extends Extension
         $configuration = [
             'entityId' => $identityProvider['entity_id'],
             'ssoUrl' => $identityProvider['sso_url'],
-            'certificateData' => $identityProvider['certificate'],
         ];
+
+        if (isset($identityProvider['certificate_file']) && !isset($identityProvider['certificate'])) {
+            $configuration['certificateFile'] = $identityProvider['certificate_file'];
+        } elseif (isset($identityProvider['certificate'])) {
+            $configuration['certificateData'] = $identityProvider['certificate'];
+        } else {
+            throw new InvalidConfigurationException(
+                'Either surfnet_saml.remote.identity_provider.certificate_file or surfnet_saml.remote.identity_provider.certificate must be set.'
+            );
+        }
 
         $definition->setArguments([$configuration]);
         $container->setDefinition('surfnet_saml.remote.idp', $definition);


### PR DESCRIPTION
This allows one to specify a file containing the remote IdP signing certificate instead of having to inline it into the confuration file.