### PR TITLE
Let BridgeContainer only generate correct identifiers

### DIFF
--- a/src/SAML2/BridgeContainer.php
+++ b/src/SAML2/BridgeContainer.php
@@ -51,7 +51,7 @@ class BridgeContainer extends SAML2_Compat_AbstractContainer
      */
     public function generateId()
     {
-        return '_' . base64_encode(openssl_random_pseudo_bytes(30));
+        return '_' . bin2hex(openssl_random_pseudo_bytes(30));
     }
 
     public function debugMessage($message, $type)


### PR DESCRIPTION
Fixes #48 