### PR TITLE
Allow unkown attributes in profile

### DIFF
--- a/src/Resources/config/saml_attributes.yml
+++ b/src/Resources/config/saml_attributes.yml
@@ -1,4 +1,12 @@
 services:
+    saml.attribute.unknown:
+    class: Surfnet\SamlBundle\SAML2\Attribute\AttributeDefinition
+    arguments:
+    - unknown
+    - 'urn:mace:dir:attribute-def:unknown'
+    tags:
+    - { name: 'saml.attribute' }
+    
     saml.attribute.commonName:
         class: Surfnet\SamlBundle\SAML2\Attribute\AttributeDefinition
         arguments:

--- a/src/SAML2/Attribute/AttributeDictionary.php
+++ b/src/SAML2/Attribute/AttributeDictionary.php
@@ -127,6 +127,6 @@ class AttributeDictionary
             return $this->attributeDefinitionsByUrn[$urn];
         }
 
-        throw new UnknownUrnException($urn);
+        return $this->attributeDefinitionsByUrn['urn:mace:dir:attribute-def:unknown'];
     }
 }


### PR DESCRIPTION
This patch also requires a translation for profile.saml.attributes.unknown in profile app/Resources/translations
