### PR TITLE
Add configurable attribute set creation

### DIFF
--- a/src/SAML2/Attribute/AttributeSet.php
+++ b/src/SAML2/Attribute/AttributeSet.php
@@ -28,7 +28,7 @@ class AttributeSet implements AttributeSetFactory, AttributeSetInterface
     /**
      * @var Attribute[]
      */
-    protected $attributes = [];
+    private $attributes = [];
 
     public static function createFrom(SAML2_Assertion $assertion, AttributeDictionary $attributeDictionary)
     {

--- a/src/SAML2/Attribute/AttributeSet.php
+++ b/src/SAML2/Attribute/AttributeSet.php
@@ -28,7 +28,7 @@ class AttributeSet implements AttributeSetFactory, AttributeSetInterface
     /**
      * @var Attribute[]
      */
-    private $attributes = [];
+    protected $attributes = [];
 
     public static function createFrom(SAML2_Assertion $assertion, AttributeDictionary $attributeDictionary)
     {
@@ -113,7 +113,7 @@ class AttributeSet implements AttributeSetFactory, AttributeSetInterface
      *
      * @SuppressWarnings(PHPMD.UnusedPrivateMethod) PHPMD does not see that this is being called in our static method
      */
-    private function initializeWith(Attribute $attribute)
+    protected function initializeWith(Attribute $attribute)
     {
         if ($this->contains($attribute)) {
             return;

--- a/src/SAML2/Attribute/AttributeSet.php
+++ b/src/SAML2/Attribute/AttributeSet.php
@@ -19,24 +19,17 @@
 namespace Surfnet\SamlBundle\SAML2\Attribute;
 
 use ArrayIterator;
-use Countable;
-use IteratorAggregate;
 use SAML2_Assertion;
 use Surfnet\SamlBundle\Exception\RuntimeException;
 use Surfnet\SamlBundle\SAML2\Attribute\Filter\AttributeFilter;
 
-final class AttributeSet implements IteratorAggregate, Countable
+class AttributeSet implements AttributeSetFactory, AttributeSetInterface
 {
     /**
      * @var Attribute[]
      */
     private $attributes = [];
 
-    /**
-     * @param SAML2_Assertion $assertion
-     * @param AttributeDictionary $attributeDictionary
-     * @return AttributeSet
-     */
     public static function createFrom(SAML2_Assertion $assertion, AttributeDictionary $attributeDictionary)
     {
         $attributeSet = new AttributeSet();
@@ -49,10 +42,6 @@ final class AttributeSet implements IteratorAggregate, Countable
         return $attributeSet;
     }
 
-    /**
-     * @param Attribute[] $attributes
-     * @return AttributeSet
-     */
     public static function create(array $attributes)
     {
         $attributeSet = new AttributeSet();
@@ -68,19 +57,11 @@ final class AttributeSet implements IteratorAggregate, Countable
     {
     }
 
-    /**
-     * @param AttributeFilter $attributeFilter
-     * @return AttributeSet
-     */
     public function apply(AttributeFilter $attributeFilter)
     {
         return self::create(array_filter($this->attributes, [$attributeFilter, 'allows']));
     }
 
-    /**
-     * @param AttributeDefinition $attributeDefinition
-     * @return Attribute
-     */
     public function getAttributeByDefinition(AttributeDefinition $attributeDefinition)
     {
         foreach ($this->attributes as $attribute) {
@@ -95,10 +76,6 @@ final class AttributeSet implements IteratorAggregate, Countable
         ));
     }
 
-    /**
-     * @param AttributeDefinition $attributeDefinition
-     * @return bool
-     */
     public function containsAttributeDefinedBy(AttributeDefinition $attributeDefinition)
     {
         foreach ($this->attributes as $attribute) {
@@ -110,10 +87,6 @@ final class AttributeSet implements IteratorAggregate, Countable
         return false;
     }
 
-    /**
-     * @param Attribute $otherAttribute
-     * @return bool
-     */
     public function contains(Attribute $otherAttribute)
     {
         foreach ($this->attributes as $attribute) {

--- a/src/SAML2/Attribute/AttributeSetFactory.php
+++ b/src/SAML2/Attribute/AttributeSetFactory.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * Copyright 2016 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\SamlBundle\SAML2\Attribute;
+
+use SAML2_Assertion;
+
+interface AttributeSetFactory
+{
+    /**
+     * @param SAML2_Assertion $assertion
+     * @param AttributeDictionary $attributeDictionary
+     * @return AttributeSet
+     *
+     * @deprecated Will be replaced with different creation implementation
+     */
+    public static function createFrom(SAML2_Assertion $assertion, AttributeDictionary $attributeDictionary);
+
+    /**
+     * @param Attribute[] $attributes
+     * @return AttributeSet
+     *
+     * @deprecated Will be replaced with different creation implementation
+     */
+    public static function create(array $attributes);
+}

--- a/src/SAML2/Attribute/AttributeSetFactory.php
+++ b/src/SAML2/Attribute/AttributeSetFactory.php
@@ -25,7 +25,7 @@ interface AttributeSetFactory
     /**
      * @param SAML2_Assertion $assertion
      * @param AttributeDictionary $attributeDictionary
-     * @return AttributeSet
+     * @return AttributeSetInterface
      *
      * @deprecated Will be replaced with different creation implementation
      */
@@ -33,7 +33,7 @@ interface AttributeSetFactory
 
     /**
      * @param Attribute[] $attributes
-     * @return AttributeSet
+     * @return AttributeSetInterface
      *
      * @deprecated Will be replaced with different creation implementation
      */

--- a/src/SAML2/Attribute/AttributeSetInterface.php
+++ b/src/SAML2/Attribute/AttributeSetInterface.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * Copyright 2016 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\SamlBundle\SAML2\Attribute;
+
+use Countable;
+use IteratorAggregate;
+use Surfnet\SamlBundle\SAML2\Attribute\Filter\AttributeFilter;
+
+interface AttributeSetInterface extends IteratorAggregate, Countable
+{
+    /**
+     * @param AttributeFilter $attributeFilter
+     * @return AttributeSet
+     */
+    public function apply(AttributeFilter $attributeFilter);
+
+    /**
+     * @param AttributeDefinition $attributeDefinition
+     * @return Attribute
+     */
+    public function getAttributeByDefinition(AttributeDefinition $attributeDefinition);
+
+    /**
+     * @param AttributeDefinition $attributeDefinition
+     * @return bool
+     */
+    public function containsAttributeDefinedBy(AttributeDefinition $attributeDefinition);
+
+    /**
+     * @param Attribute $otherAttribute
+     * @return bool
+     */
+    public function contains(Attribute $otherAttribute);
+}

--- a/src/SAML2/Attribute/AttributeSetInterface.php
+++ b/src/SAML2/Attribute/AttributeSetInterface.php
@@ -26,13 +26,13 @@ interface AttributeSetInterface extends IteratorAggregate, Countable
 {
     /**
      * @param AttributeFilter $attributeFilter
-     * @return AttributeSet
+     * @return AttributeSetInterface
      */
     public function apply(AttributeFilter $attributeFilter);
 
     /**
      * @param AttributeDefinition $attributeDefinition
-     * @return Attribute
+     * @return AttributeSetInterface
      */
     public function getAttributeByDefinition(AttributeDefinition $attributeDefinition);
 

--- a/src/SAML2/Attribute/ConfigurableAttributeSetFactory.php
+++ b/src/SAML2/Attribute/ConfigurableAttributeSetFactory.php
@@ -1,0 +1,61 @@
+<?php
+
+/**
+ * Copyright 2016 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\SamlBundle\SAML2\Attribute;
+
+use SAML2_Assertion;
+use Surfnet\SamlBundle\Exception\InvalidArgumentException;
+
+final class ConfigurableAttributeSetFactory implements AttributeSetFactory
+{
+    private static $attributeSetClassName = AttributeSet::class;
+
+    /**
+     * @param string $attributeSetClassName
+     */
+    public static function configureWhichAttributeSetToCreate($attributeSetClassName)
+    {
+        if (!is_string($attributeSetClassName) || empty($attributeSetClassName)) {
+            throw InvalidArgumentException::invalidType('non-empty string', 'attributeSetClassName', $attributeSetClassName);
+        }
+
+        if (!is_a($attributeSetClassName, AttributeSetFactory::class, true)) {
+            throw new InvalidArgumentException(sprintf(
+                'Cannot use class "%s": it must implement "%s"',
+                $attributeSetClassName,
+                AttributeSetFactory::class
+            ));
+        }
+
+        self::$attributeSetClassName = $attributeSetClassName;
+    }
+
+    public static function createFrom(SAML2_Assertion $assertion, AttributeDictionary $attributeDictionary)
+    {
+        $class = self::$attributeSetClassName;
+
+        return $class::createFrom($assertion, $attributeDictionary);
+    }
+
+    public static function create(array $attributes)
+    {
+        $class = self::$attributeSetClassName;
+
+        return $class::create($attributes);
+    }
+}

--- a/src/SAML2/Attribute/ConfigurableAttributeSetFactory.php
+++ b/src/SAML2/Attribute/ConfigurableAttributeSetFactory.php
@@ -23,7 +23,7 @@ use Surfnet\SamlBundle\Exception\InvalidArgumentException;
 
 final class ConfigurableAttributeSetFactory implements AttributeSetFactory
 {
-    private static $attributeSetClassName = AttributeSet::class;
+    private static $attributeSetClassName = 'Surfnet\SamlBundle\SAML2\Attribute\AttributeSet';
 
     /**
      * @param string $attributeSetClassName
@@ -34,11 +34,11 @@ final class ConfigurableAttributeSetFactory implements AttributeSetFactory
             throw InvalidArgumentException::invalidType('non-empty string', 'attributeSetClassName', $attributeSetClassName);
         }
 
-        if (!is_a($attributeSetClassName, AttributeSetFactory::class, true)) {
+        if (!is_a($attributeSetClassName, '\Surfnet\SamlBundle\SAML2\Attribute\AttributeSetFactory', true)) {
             throw new InvalidArgumentException(sprintf(
                 'Cannot use class "%s": it must implement "%s"',
                 $attributeSetClassName,
-                AttributeSetFactory::class
+                '\Surfnet\SamlBundle\SAML2\Attribute\AttributeSetFactory'
             ));
         }
 

--- a/src/SAML2/Response/AssertionAdapter.php
+++ b/src/SAML2/Response/AssertionAdapter.php
@@ -20,7 +20,8 @@ namespace Surfnet\SamlBundle\SAML2\Response;
 
 use SAML2_Assertion;
 use Surfnet\SamlBundle\SAML2\Attribute\AttributeDictionary;
-use Surfnet\SamlBundle\SAML2\Attribute\AttributeSet;
+use Surfnet\SamlBundle\SAML2\Attribute\AttributeSetInterface;
+use Surfnet\SamlBundle\SAML2\Attribute\ConfigurableAttributeSetFactory;
 
 class AssertionAdapter
 {
@@ -30,7 +31,7 @@ class AssertionAdapter
     private $assertion;
 
     /**
-     * @var AttributeSet
+     * @var AttributeSetInterface
      */
     private $attributeSet;
 
@@ -42,7 +43,7 @@ class AssertionAdapter
     public function __construct(SAML2_Assertion $assertion, AttributeDictionary $attributeDictionary)
     {
         $this->assertion           = $assertion;
-        $this->attributeSet        = AttributeSet::createFrom($assertion, $attributeDictionary);
+        $this->attributeSet        = ConfigurableAttributeSetFactory::createFrom($assertion, $attributeDictionary);
         $this->attributeDictionary = $attributeDictionary;
     }
 
@@ -78,7 +79,7 @@ class AssertionAdapter
     }
 
     /**
-     * @return AttributeSet
+     * @return AttributeSetInterface
      */
     public function getAttributeSet()
     {

--- a/src/Tests/SAML2/Attribute/AttributeDictionaryTest.php
+++ b/src/Tests/SAML2/Attribute/AttributeDictionaryTest.php
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-namespace SAML2\Attribute;
+namespace Surfnet\SamlBundle\Tests\SAML2\Attribute;
 
 use PHPUnit_Framework_TestCase as TestCase;
 use Surfnet\SamlBundle\SAML2\Attribute\AttributeDefinition;

--- a/src/Tests/SAML2/Attribute/ConfigurableAttributeSetFactoryTest.php
+++ b/src/Tests/SAML2/Attribute/ConfigurableAttributeSetFactoryTest.php
@@ -21,7 +21,6 @@ namespace Surfnet\SamlBundle\Tests\SAML2\Attribute;
 use PHPUnit_Framework_TestCase as TestCase;
 use SAML2_Assertion;
 use stdClass;
-use Surfnet\SamlBundle\Exception\InvalidArgumentException;
 use Surfnet\SamlBundle\SAML2\Attribute\AttributeDictionary;
 use Surfnet\SamlBundle\SAML2\Attribute\ConfigurableAttributeSetFactory;
 

--- a/src/Tests/SAML2/Attribute/ConfigurableAttributeSetFactoryTest.php
+++ b/src/Tests/SAML2/Attribute/ConfigurableAttributeSetFactoryTest.php
@@ -23,12 +23,12 @@ use SAML2_Assertion;
 use stdClass;
 use Surfnet\SamlBundle\Exception\InvalidArgumentException;
 use Surfnet\SamlBundle\SAML2\Attribute\AttributeDictionary;
-use Surfnet\SamlBundle\SAML2\Attribute\AttributeSet;
 use Surfnet\SamlBundle\SAML2\Attribute\ConfigurableAttributeSetFactory;
-use Surfnet\SamlBundle\Tests\SAML2\Attribute\Mock\DummyAttributeSet;
 
 class ConfigurableAttributeSetFactoryTest extends TestCase
 {
+    const DUMMY_ATTRIBUTE_SET_CLASS = '\Surfnet\SamlBundle\Tests\SAML2\Attribute\Mock\DummyAttributeSet';
+    
     /**
      * @test
      * @group AssertionAdapter
@@ -36,11 +36,13 @@ class ConfigurableAttributeSetFactoryTest extends TestCase
      */
     public function which_attribute_set_is_created_from_a_saml_assertion_is_configurable()
     {
-        ConfigurableAttributeSetFactory::configureWhichAttributeSetToCreate(DummyAttributeSet::class);
+        ConfigurableAttributeSetFactory::configureWhichAttributeSetToCreate(self::DUMMY_ATTRIBUTE_SET_CLASS);
         $attributeSet = ConfigurableAttributeSetFactory::createFrom(new SAML2_Assertion, new AttributeDictionary);
-        ConfigurableAttributeSetFactory::configureWhichAttributeSetToCreate(AttributeSet::class);
+        ConfigurableAttributeSetFactory::configureWhichAttributeSetToCreate(
+            '\Surfnet\SamlBundle\SAML2\Attribute\AttributeSet'
+        );
 
-        $this->assertInstanceOf(DummyAttributeSet::class, $attributeSet);
+        $this->assertInstanceOf(self::DUMMY_ATTRIBUTE_SET_CLASS, $attributeSet);
     }
 
     /**
@@ -50,11 +52,13 @@ class ConfigurableAttributeSetFactoryTest extends TestCase
      */
     public function which_attribute_set_is_created_from_attributes_is_configurable()
     {
-        ConfigurableAttributeSetFactory::configureWhichAttributeSetToCreate(DummyAttributeSet::class);
+        ConfigurableAttributeSetFactory::configureWhichAttributeSetToCreate(self::DUMMY_ATTRIBUTE_SET_CLASS);
         $attributeSet = ConfigurableAttributeSetFactory::create([]);
-        ConfigurableAttributeSetFactory::configureWhichAttributeSetToCreate(AttributeSet::class);
+        ConfigurableAttributeSetFactory::configureWhichAttributeSetToCreate(
+            '\Surfnet\SamlBundle\SAML2\Attribute\AttributeSet'
+        );
 
-        $this->assertInstanceOf(DummyAttributeSet::class, $attributeSet);
+        $this->assertInstanceOf(self::DUMMY_ATTRIBUTE_SET_CLASS, $attributeSet);
     }
 
     /**

--- a/src/Tests/SAML2/Attribute/ConfigurableAttributeSetFactoryTest.php
+++ b/src/Tests/SAML2/Attribute/ConfigurableAttributeSetFactoryTest.php
@@ -70,7 +70,7 @@ class ConfigurableAttributeSetFactoryTest extends TestCase
      */
     public function the_attribute_set_to_use_can_only_be_represented_as_a_non_empty_string($nonOrEmptyString)
     {
-        $this->setExpectedException(InvalidArgumentException::class, 'non-empty string');
+        $this->setExpectedException('\Surfnet\SamlBundle\Exception\InvalidArgumentException', 'non-empty string');
 
         ConfigurableAttributeSetFactory::configureWhichAttributeSetToCreate($nonOrEmptyString);
     }
@@ -82,7 +82,7 @@ class ConfigurableAttributeSetFactoryTest extends TestCase
      */
     public function the_attribute_set_to_use_has_to_implement_attribute_set_factory()
     {
-        $this->setExpectedException(InvalidArgumentException::class, 'implement');
+        $this->setExpectedException('\Surfnet\SamlBundle\Exception\InvalidArgumentException', 'implement');
 
         ConfigurableAttributeSetFactory::configureWhichAttributeSetToCreate('Non\Existent\Class');
     }

--- a/src/Tests/SAML2/Attribute/ConfigurableAttributeSetFactoryTest.php
+++ b/src/Tests/SAML2/Attribute/ConfigurableAttributeSetFactoryTest.php
@@ -1,0 +1,97 @@
+<?php
+
+/**
+ * Copyright 2016 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\SamlBundle\Tests\SAML2\Attribute;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use SAML2_Assertion;
+use stdClass;
+use Surfnet\SamlBundle\Exception\InvalidArgumentException;
+use Surfnet\SamlBundle\SAML2\Attribute\AttributeDictionary;
+use Surfnet\SamlBundle\SAML2\Attribute\AttributeSet;
+use Surfnet\SamlBundle\SAML2\Attribute\ConfigurableAttributeSetFactory;
+use Surfnet\SamlBundle\Tests\SAML2\Attribute\Mock\DummyAttributeSet;
+
+class ConfigurableAttributeSetFactoryTest extends TestCase
+{
+    /**
+     * @test
+     * @group AssertionAdapter
+     * @group AttributeSet
+     */
+    public function which_attribute_set_is_created_from_a_saml_assertion_is_configurable()
+    {
+        ConfigurableAttributeSetFactory::configureWhichAttributeSetToCreate(DummyAttributeSet::class);
+        $attributeSet = ConfigurableAttributeSetFactory::createFrom(new SAML2_Assertion, new AttributeDictionary);
+        ConfigurableAttributeSetFactory::configureWhichAttributeSetToCreate(AttributeSet::class);
+
+        $this->assertInstanceOf(DummyAttributeSet::class, $attributeSet);
+    }
+
+    /**
+     * @test
+     * @group AssertionAdapter
+     * @group AttributeSet
+     */
+    public function which_attribute_set_is_created_from_attributes_is_configurable()
+    {
+        ConfigurableAttributeSetFactory::configureWhichAttributeSetToCreate(DummyAttributeSet::class);
+        $attributeSet = ConfigurableAttributeSetFactory::create([]);
+        ConfigurableAttributeSetFactory::configureWhichAttributeSetToCreate(AttributeSet::class);
+
+        $this->assertInstanceOf(DummyAttributeSet::class, $attributeSet);
+    }
+
+    /**
+     * @test
+     * @group AssertionAdapter
+     * @group AttributeSet
+     *
+     * @dataProvider nonOrEmptyStringProvider()
+     */
+    public function the_attribute_set_to_use_can_only_be_represented_as_a_non_empty_string($nonOrEmptyString)
+    {
+        $this->setExpectedException(InvalidArgumentException::class, 'non-empty string');
+
+        ConfigurableAttributeSetFactory::configureWhichAttributeSetToCreate($nonOrEmptyString);
+    }
+
+    /**
+     * @test
+     * @group AssertionAdapter
+     * @group AttributeSet
+     */
+    public function the_attribute_set_to_use_has_to_implement_attribute_set_factory()
+    {
+        $this->setExpectedException(InvalidArgumentException::class, 'implement');
+
+        ConfigurableAttributeSetFactory::configureWhichAttributeSetToCreate('Non\Existent\Class');
+    }
+
+    public function nonOrEmptyStringProvider()
+    {
+        return [
+            'integer'      => [1],
+            'float'        => [1.23],
+            'boolean'      => [true],
+            'array'        => [[]],
+            'object'       => [new stdClass],
+            'empty string' => [''],
+        ];
+    }
+}

--- a/src/Tests/SAML2/Attribute/Mock/DummyAttributeSet.php
+++ b/src/Tests/SAML2/Attribute/Mock/DummyAttributeSet.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * Copyright 2016 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\SamlBundle\Tests\SAML2\Attribute\Mock;
+
+use SAML2_Assertion;
+use Surfnet\SamlBundle\SAML2\Attribute\AttributeDictionary;
+use Surfnet\SamlBundle\SAML2\Attribute\AttributeSetFactory;
+
+final class DummyAttributeSet implements AttributeSetFactory
+{
+    public static function createFrom(SAML2_Assertion $assertion, AttributeDictionary $attributeDictionary)
+    {
+        return new self;
+    }
+
+    public static function create(array $attributes)
+    {
+        return new self;
+    }
+}


### PR DESCRIPTION
Part of OpenConext/OpenConext-Profile#55
This relates to #50.

In order to allow clients (such as Profile) to let attribute sets contain 'unknown' attributes, we're offering a way to change which AttributeSet is (statically) configured. This way, the client could use his own class and define his own rules regarding the AttributeSet in a non-BC-breaking manner.

We're deprecating this way of creating AttributeSets as well, because we favour a more transparent, compositional way above configuration through static properties. However, that would be a BC-break impacting all dependent projects. This PR does not.