### PR TITLE
Upgrade simplesamlphp/saml2 to ^4.20.3 and fix moved Chunk namespace

### DIFF
--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -6,7 +6,7 @@ jobs:
     continue-on-error: ${{ matrix.experimental }}
     strategy:
       matrix:
-        php-versions: [ '8.2', '8.4']
+        php-versions: [ '8.3', '8.4']
         experimental: [false]
     timeout-minutes: 15
     name: PHP ${{ matrix.php-versions }} on Ubuntu latest. Experimental == ${{ matrix.experimental }}

--- a/ci/qa/phpstan-baseline.neon
+++ b/ci/qa/phpstan-baseline.neon
@@ -487,12 +487,6 @@ parameters:
 			path: ../../src/SAML2/AuthnRequest.php
 
 		-
-			message: '#^Method Surfnet\\SamlBundle\\SAML2\\AuthnRequest\:\:getAuthenticationContextClassRef\(\) should return string\|null but returns mixed\.$#'
-			identifier: return.type
-			count: 1
-			path: ../../src/SAML2/AuthnRequest.php
-
-		-
 			message: '#^Method Surfnet\\SamlBundle\\SAML2\\AuthnRequest\:\:getDestination\(\) should return string but returns string\|null\.$#'
 			identifier: return.type
 			count: 1
@@ -525,12 +519,6 @@ parameters:
 		-
 			message: '#^Method Surfnet\\SamlBundle\\SAML2\\AuthnRequest\:\:signRequestQuery\(\) has parameter \$queryParams with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
-			count: 1
-			path: ../../src/SAML2/AuthnRequest.php
-
-		-
-			message: '#^Parameter \#1 \$array of function reset expects array\|object, mixed given\.$#'
-			identifier: argument.type
 			count: 1
 			path: ../../src/SAML2/AuthnRequest.php
 
@@ -679,12 +667,6 @@ parameters:
 			path: ../../src/SAML2/ReceivedAuthnRequest.php
 
 		-
-			message: '#^Method Surfnet\\SamlBundle\\SAML2\\ReceivedAuthnRequest\:\:getAuthenticationContextClassRef\(\) should return string\|null but returns mixed\.$#'
-			identifier: return.type
-			count: 1
-			path: ../../src/SAML2/ReceivedAuthnRequest.php
-
-		-
 			message: '#^Method Surfnet\\SamlBundle\\SAML2\\ReceivedAuthnRequest\:\:getScopingRequesterIds\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
@@ -705,12 +687,6 @@ parameters:
 		-
 			message: '#^Method Surfnet\\SamlBundle\\SAML2\\ReceivedAuthnRequest\:\:setScoping\(\) has parameter \$requesterIds with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
-			count: 1
-			path: ../../src/SAML2/ReceivedAuthnRequest.php
-
-		-
-			message: '#^Parameter \#1 \$array of function reset expects array\|object, mixed given\.$#'
-			identifier: argument.type
 			count: 1
 			path: ../../src/SAML2/ReceivedAuthnRequest.php
 

--- a/composer.json
+++ b/composer.json
@@ -6,12 +6,12 @@
     "license": "Apache-2.0",
     "minimum-stability": "stable",
     "require": {
-        "php": "^8.1",
+        "php": "^8.3",
         "ext-dom": "*",
         "ext-openssl": "*",
         "psr/log": "^3.0",
         "robrichards/xmlseclibs": "^3.1.4",
-        "simplesamlphp/saml2": "^4.6",
+        "simplesamlphp/saml2": "^4.20.3",
         "symfony/dependency-injection": "^6.3|^7.0",
         "symfony/framework-bundle": "^6.3|^7.0",
         "symfony/security-bundle": "^6.3|^7.0",
@@ -24,7 +24,6 @@
     "require-dev": {
         "ext-libxml": "*",
         "ext-zlib": "*",
-        "irstea/phpcpd-shim": "^6.0",
         "malukenho/docheader": "^1.1",
         "mockery/mockery": "^1.5",
         "overtrue/phplint": "*",
@@ -36,6 +35,7 @@
         "sebastian/exporter": "^6.3",
         "slevomat/coding-standard": "^8.24",
         "squizlabs/php_codesniffer": "^4.0",
+        "systemsdk/phpcpd": "8.0.0",
         "symfony/phpunit-bridge": "^7.3.4"
     },
     "scripts": {

--- a/src/SAML2/BridgeContainer.php
+++ b/src/SAML2/BridgeContainer.php
@@ -50,7 +50,7 @@ class BridgeContainer extends AbstractContainer
         return '_' . bin2hex(openssl_random_pseudo_bytes(30));
     }
 
-    public function debugMessage($message, $type): void
+    public function debugMessage($message, string $type): void
     {
         if ($message instanceof DOMElement) {
             $message = $message->ownerDocument->saveXML($message);
@@ -63,12 +63,12 @@ class BridgeContainer extends AbstractContainer
         $this->logger->debug($message, ['type' => $type]);
     }
 
-    public function redirect($url, $data = []): void
+    public function redirect(string $url, array $data = []): void
     {
         $this->notSupported(__METHOD__);
     }
 
-    public function postRedirect($url, $data = []): void
+    public function postRedirect(string $url, array $data = []): void
     {
         $this->notSupported(__METHOD__);
     }
@@ -77,7 +77,6 @@ class BridgeContainer extends AbstractContainer
     public function getTempDir(): string
     {
         $this->notSupported(__METHOD__);
-        return '';
     }
 
     public function writeFile(string $filename, string $data, ?int $mode = null): void
@@ -85,7 +84,7 @@ class BridgeContainer extends AbstractContainer
         $this->notSupported(__METHOD__);
     }
 
-    public function notSupported(string $method): void
+    public function notSupported(string $method): never
     {
         throw new BadMethodCallException(sprintf(
             "%s:%s may not be called in the Surfnet\\SamlBundle",

--- a/src/SAML2/Extensions/ExtensionsMapperTrait.php
+++ b/src/SAML2/Extensions/ExtensionsMapperTrait.php
@@ -18,7 +18,7 @@
 
 namespace Surfnet\SamlBundle\SAML2\Extensions;
 
-use SAML2\XML\Chunk as SAML2Chunk;
+use SimpleSAML\XML\Chunk as SAML2Chunk;
 
 trait ExtensionsMapperTrait
 {


### PR DESCRIPTION
## Summary
- Require PHP ^8.3 and simplesamlphp/saml2 ^4.20.3
- Update the moved XML Chunk namespace to SimpleSAML\XML\Chunk
- Align BridgeContainer method signatures with the updated SAML2 container contract
- Replace the unreachable phpcpd shim with systemsdk/phpcpd 8.0.0 for dev checks
- Update the integration test matrix to PHP 8.3/8.4 and clean stale PHPStan baseline entries

## Verification
- composer update --no-interaction
- composer check-ci
- composer audit
- php -l src/SAML2/BridgeContainer.php
- ./ci/qa/phpstan